### PR TITLE
:wrench: Switch to using postcss-preset-env

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "laravel-mix": "^4.0",
         "laravel-mix-purgecss": "^4.0.0",
         "postcss-import": "^12.0.1",
-        "postcss-nested": "^4.1.2",
         "postcss-preset-env": "^6.7.0",
         "tailwindcss": "^1.1.2",
         "vue-template-compiler": "^2.6.11"

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -16,8 +16,7 @@ mix.js('resources/js/site.js', 'public/js')
 mix.postCss('resources/css/tailwind.css', 'public/css', [
   require('postcss-import'),
   require('tailwindcss'),
-  require('postcss-nested'),
-  require('autoprefixer'),
+  require('postcss-preset-env')({stage: 0})
 ])
 
 if (mix.inProduction()) {


### PR DESCRIPTION
Nothing major in this PR; just some optimisations to the build tools:

**package.json**
This change removes the postcss-nested package which is available in stage-0 of postcss-preset-env and so is a duplicated package.

**webpack.mix.js**
Swap out the requires for nesting and autoprefixer and replace them postcss-preset-env stage 0, which includes both of these features anyway.

**Testing**
Fresh install, installed the packages and ran the build script. Checked every page of the theme. All works.