### PR TITLE
Fixes problem if "excerpt" is blank

### DIFF
--- a/resources/views/home.antlers.html
+++ b/resources/views/home.antlers.html
@@ -20,7 +20,7 @@
                 </h2>
                 <p class="text-gray-600">
                     <span class="text-gray-800 text-sm uppercase tracking-widest font-medium">{{ date }}</span> &mdash;
-                    {{ excerpt | widont ?? content | strip_tags | safe_truncate:160:...}}
+                    {{ excerpt ? excerpt | widont : content | strip_tags | safe_truncate:160:...}}
                 </p>
             </div>
         {{ /articles }}


### PR DESCRIPTION
Fixes problem where if "excerpt" is blank, the first 160 characters of "content" are not displayed. This is related to "Null Coalescence doesn't return fallback if falsey variable uses a modifier #2022" issue located at https://github.com/statamic/cms/issues/2022