### PR TITLE
Show Only Published Entries / Excerpt Fix

### DIFF
--- a/resources/views/topics/show.antlers.html
+++ b/resources/views/topics/show.antlers.html
@@ -8,16 +8,18 @@
 </div>
 <div class="max-w-2xl mx-auto mb-32">
     {{ entries }}
-    <div class="mb-16">
-        <h2 class="mb-4">
-            <a href="{{ url }}" class="text-2xl hover:text-teal tracking-tight leading-tight font-bold">
-                {{ title | widont }}
-            </a>
-        </h2>
-        <p class="text-gray-600">
-            <span class="text-gray-800 text-sm uppercase tracking-widest font-medium">{{ date }}</span> &mdash;
-            {{ excerpt | widont ?? content | strip_tags | safe_truncate:160:...}}
-        </p>
-    </div>
+      {{ if published }}
+        <div class="mb-16">
+            <h2 class="mb-4">
+                <a href="{{ url }}" class="text-2xl hover:text-teal tracking-tight leading-tight font-bold">
+                    {{ title | widont }}
+                </a>
+            </h2>
+            <p class="text-gray-600">
+                <span class="text-gray-800 text-sm uppercase tracking-widest font-medium">{{ date }}</span> &mdash;
+                {{ excerpt ? excerpt | widont : content | strip_tags | safe_truncate:160:...}}
+            </p>
+        </div>
+      {{ /if }}
     {{ /entries }}
 </div>


### PR DESCRIPTION
- Add check to only show "published" entries under "Topics"

Fixes https://github.com/statamic/starter-kit-cool-writings/issues/30 issue.

It sounds like showing unpublished/draft entries is potentially related to https://github.com/statamic/cms/issues/2721

I also wanted to add a check to make sure there was at least one entry under the topic and show "No entries found for this topic." message if none were found, but I can't find a way to do that within the Statamic docs. I tried {{ increment }}, but it doesn't seem like you can use that to check if it has incremented against an "if" statement.

- Fixes problem if "excerpt" is blank like in https://github.com/statamic/starter-kit-cool-writings/pull/31