### PR TITLE
Fixing mobile nav

### DIFF
--- a/resources/js/site.js
+++ b/resources/js/site.js
@@ -1,2 +1,3 @@
 // Alpine.js handles the show/hide of the mobile nav
-import 'alpinejs'
+import Alpine from 'alpinejs'
+Alpine.start()

--- a/resources/views/_nav.antlers.html
+++ b/resources/views/_nav.antlers.html
@@ -17,7 +17,7 @@
             </svg>
         </button>
     </div>
-    <div class="w-full lg:w-auto lg:flex items-center" @click.away="showMobileNav = false" x-bind:class="{ 'hidden': ! showMobileNav }">
+    <div class="w-full lg:w-auto lg:flex items-center" @click.outside="showMobileNav = false" x-show="showMobileNav">
         {{ nav }}
         <a href="{{ url }}" class="block {{ is_current || is_parent ?= 'font-medium text-gray-800' }} mt-4 lg:inline-block text-gray-600 hover:text-gray-800 lg:mt-0 mr-12">
             {{ title }}

--- a/resources/views/layout.antlers.html
+++ b/resources/views/layout.antlers.html
@@ -8,7 +8,7 @@
         <meta name="description" content="{{ excerpt ?? title }}">
         <meta name="theme-color" content="00908F">
         <link rel="stylesheet" href="{{ mix src='css/tailwind.css' }}">
-        <script src="{{ mix src='/js/site.js' }}"></script>
+        <script src="{{ mix src='/js/site.js' }} defer"></script>
     </head>
     <body class="bg-white font-sans leading-normal text-grey-800 px-4 sm:px-10" x-data="{ showMobileNav: false }">
         {{ partial:nav }}

--- a/starter-kit.yaml
+++ b/starter-kit.yaml
@@ -5,6 +5,7 @@ export_paths:
   - resources/blueprints
   - resources/fieldsets
   - resources/css
+  - resources/js
   - resources/views
   - public/assets
   - public/css


### PR DESCRIPTION
The mobile nav did not work because Alpine wasn't initialized properly. Fixed this and applied new Alpine syntax (@click.outside instead of .away)

Nav looked like this before this PR (shows both buttons and doesn't do anything when clicking either of them):
![CleanShot 2022-03-26 at 1 40 34](https://user-images.githubusercontent.com/3824203/160239881-89e6e005-36e3-4a1c-80f1-e8890b7dcb39.png)
